### PR TITLE
:sparkles: Add type definitions

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,14 @@
+import { ReactThreeFiber } from 'react-three-fiber';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
+import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            effectComposer: ReactThreeFiber.Node<EffectComposer,typeof EffectComposer>;
+            renderPass: ReactThreeFiber.Node<RenderPass, typeof RenderPass>;
+            shaderPass: ReactThreeFiber.Node<ShaderPass, typeof ShaderPass>;
+        }
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "lib": [
       "es2020",
       "dom"
-    ]
+    ],
+    "baseUrl": ".",
+    "typeRoots": ["src/types", "node_modules/@types"]
   }
 }


### PR DESCRIPTION
# Summary

There is a lack of type definitions for three.js objects, so added those.

TypeScriptのInterfaceはもとからある名前(今回はJSX)をもう一回自前で宣言すると、元の型定義とマージされる感じになるので、こんな感じでいけます。
もし他のthree.jsオブジェクトの型定義が無いって時も、同じように自前で生やせばなんとかなるかもしれません！(無責任)